### PR TITLE
Improve handling of environment property

### DIFF
--- a/src/main/groovy/com.github.ocroquette.extools/internal/exec/Executor.groovy
+++ b/src/main/groovy/com.github.ocroquette.extools/internal/exec/Executor.groovy
@@ -133,9 +133,9 @@ class Executor {
             }
             String systemCase = getSystemCase(variableName)
 
-            def systemValue = System.getenv(systemCase)
-            if (systemValue != null) {
-                systemValue.split(File.pathSeparator).each { it ->
+            def baseValue = conf.environment.remove(variableName) ?: System.getenv(systemCase)
+            if (baseValue != null) {
+                baseValue.split(File.pathSeparator).each { it ->
                     paths.add(it)
                 }
             }

--- a/src/test/groovy/com.github.ocroquette.extools/ExtoolsPluginExtoolsExecTest.groovy
+++ b/src/test/groovy/com.github.ocroquette.extools/ExtoolsPluginExtoolsExecTest.groovy
@@ -217,6 +217,60 @@ class ExtoolsPluginExtoolsExecTest extends Specification {
         result.task(":$taskName").outcome == FAILED
     }
 
+    def "Environment is inherited when not explicitly set"() {
+        given:
+        def taskName = 'execImplicitEnvironment'
+        def extractDir = temporaryFolder.newFolder()
+        def expectedEnv = getSysEnv()
+        expectedEnv["PATH"] = new File(extractDir, "printenvvars/bin").canonicalPath + File.pathSeparator +
+                new File(extractDir, "dummy_2/bin").canonicalPath + File.pathSeparator +
+                getSystemPath()
+        expectedEnv["PRINTENVVARS_BIN"] = new File(extractDir, "printenvvars/bin").canonicalPath
+        expectedEnv["CMAKE_PREFIX_PATH"] = new File(extractDir, "dummy_2/cmake2").canonicalPath
+        expectedEnv["DUMMY_STRING"] = "Value of DUMMY_STRING from dummy_2"
+        expectedEnv["DUMMY2_STRING"] = "Value of DUMMY2_STRING"
+        when:
+        def result = new GradleRunnerHelper(
+                temporaryRoot: temporaryFolder.newFolder(),
+                buildScript: generateBuildScript(),
+                repositoryUrl: REPO_URL,
+                extractDir: extractDir.canonicalPath,
+                taskName: taskName,
+        ).build()
+        def actualEnv = parseEnvVariablesFromStdout(dumpFile.text)
+
+        then:
+        result.task(":$taskName").outcome == SUCCESS
+        compareEnv(expectedEnv, actualEnv) == ""
+    }
+
+    def "Environment is not inherited when explicitly set"() {
+        given:
+        def taskName = 'execExplicitEnvironment'
+        def extractDir = temporaryFolder.newFolder()
+        def expectedEnv = getSysEnv()
+        expectedEnv["PATH"] = new File(extractDir, "printenvvars/bin").canonicalPath + File.pathSeparator +
+                new File(extractDir, "dummy_2/bin").canonicalPath + File.pathSeparator +
+                "specific"
+        expectedEnv["PRINTENVVARS_BIN"] = new File(extractDir, "printenvvars/bin").canonicalPath
+        expectedEnv["CMAKE_PREFIX_PATH"] = new File(extractDir, "dummy_2/cmake2").canonicalPath
+        expectedEnv["DUMMY_STRING"] = "Value of DUMMY_STRING from dummy_2"
+        expectedEnv["DUMMY2_STRING"] = "Value of DUMMY2_STRING"
+        when:
+        def result = new GradleRunnerHelper(
+                temporaryRoot: temporaryFolder.newFolder(),
+                buildScript: generateBuildScript(),
+                repositoryUrl: REPO_URL,
+                extractDir: extractDir.canonicalPath,
+                taskName: taskName,
+        ).build()
+        def actualEnv = parseEnvVariablesFromStdout(dumpFile.text)
+
+        then:
+        result.task(":$taskName").outcome == SUCCESS
+        compareEnv(expectedEnv, actualEnv) == ""
+    }
+
     def "PATH variable is extended as required"() {
         given:
         def taskName = 'execPrintEnvVarsWithImplicitPath'

--- a/src/test/resources/build.gradle.extoolsexec
+++ b/src/test/resources/build.gradle.extoolsexec
@@ -111,6 +111,17 @@ task execPrintEnvVarsWithEnvironmentVariableSingle(type:ExtoolExec) {
     commandLine "printenvvars.$scriptExtension", "%dumpFile%"
 }
 
+task execExplicitEnvironment(type:ExtoolExec) {
+    usingAdditionalExtools "printenvvars"
+    environment "PATH": "specific"
+    commandLine "printenvvars.$scriptExtension", "%dumpFile%"
+}
+
+task execImplicitEnvironment(type:ExtoolExec) {
+    usingAdditionalExtools "printenvvars"
+    commandLine "printenvvars.$scriptExtension", "%dumpFile%"
+}
+
 task execUseAll(type:ExtoolExec) {
     // Unorder the list, we check if the variables are set in the right order in the test
     usingAdditionalExtools "dummy_1", "printenvvars", "printargs", "subdir/dummy_3"


### PR DESCRIPTION
When prepending environment variables fall back to the (already) configured environment instead of always using the system environment.